### PR TITLE
Make some classes templates

### DIFF
--- a/include/http/response_builder.h
+++ b/include/http/response_builder.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <http/http_version.h>
+#include <http/server_response.h>
+#include <http/status_code.h>
+
+namespace http
+{
+	template <typename standard_t>
+	class response_builder
+	{
+	public:
+		using string_t		 = std::string;
+		using http_version_t = http_version;
+		using status_code_t	 = status_code;
+		using headers_t		 = headers<response_header>;
+		using body_t		 = string_t;
+		using impl_t		 = standard_t::response_builder_impl_t;
+
+	public:
+		response_builder<standard_t>& with_http_version(http_version_t const& v)
+		{
+			__impl.with_http_version(v);
+			return *this;
+		}
+
+		response_builder<standard_t>& with_status_code(status_code_t const& sc)
+		{
+			__impl.with_status_code(sc);
+			return *this;
+		}
+
+		response_builder<standard_t>& with_status_message(string_t const& sm)
+		{
+			__impl.with_status_message(sm);
+			return *this;
+		}
+
+		response_builder<standard_t>& with_header(response_header const& header)
+		{
+			__impl.with_header(header);
+			return *this;
+		}
+
+		response_builder<standard_t>& with_body(string_t const& body)
+		{
+			__impl.with_body(body);
+			return *this;
+		}
+
+		server_response build() const { return __impl.build(); }
+
+	private:
+		impl_t __impl;
+	};
+} // namespace http

--- a/include/http/response_parser.h
+++ b/include/http/response_parser.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <http/response_parser_exception.h>
+#include <http/server_response_builder.h>
+
+namespace http
+{
+	template <typename standard_t>
+	class response_parser
+	{
+	public:
+		using parser_t	= standard_t::parser_t;
+		using builder_t = server_response_builder;
+
+	public:
+		response_parser() : __impl {} { }
+
+		template <typename iterator_t>
+		void parse(iterator_t const& dbegin, iterator_t const& dend)
+		{
+			__impl.parse<iterator_t>(dbegin, dend);
+		}
+
+		builder_t builder() const { return __impl.builder(); }
+
+	private:
+		template <typename iterator_t>
+		void parse_headers(iterator_t& tb, iterator_t const& dend)
+		{
+			__impl.parse_headers<iterator_t>(tb, dend);
+		}
+
+		template <typename iterator_t>
+		http_version http_version_from_string(iterator_t const& b, iterator_t const& e)
+		{
+			return __impl.http_version_from_string<iterator_t>(b, e);
+		}
+
+		template <typename iterator_t>
+		status_code status_code_from_string(iterator_t const& b, iterator_t const& e)
+		{
+			return __impl.status_code_from_string<iterator_t>(b, e);
+		}
+
+	private:
+		parser_t __impl;
+	};
+} // namespace http

--- a/include/http/response_parser.h
+++ b/include/http/response_parser.h
@@ -1,7 +1,7 @@
 #pragma once
 
+#include <http/response_builder.h>
 #include <http/response_parser_exception.h>
-#include <http/server_response_builder.h>
 
 namespace http
 {
@@ -9,8 +9,8 @@ namespace http
 	class response_parser
 	{
 	public:
-		using parser_t	= standard_t::parser_t;
-		using builder_t = server_response_builder;
+		using parser_t	= standard_t::response_parser_impl_t;
+		using builder_t = standard_t::response_builder_impl_t;
 
 	public:
 		response_parser() : __impl {} { }

--- a/include/http/standards/rfc2616.h
+++ b/include/http/standards/rfc2616.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <http/response_parser.h>
+#include <http/standards/rfc2616_response_parser_impl.h>
+
+namespace http
+{
+	class rfc2616_response_parser_impl;
+
+	struct rfc2616
+	{
+		using parser_t = rfc2616_response_parser_impl;
+	};
+
+	using rfc2616_response_parser = response_parser<rfc2616>;
+} // namespace http

--- a/include/http/standards/rfc2616.h
+++ b/include/http/standards/rfc2616.h
@@ -1,16 +1,22 @@
 #pragma once
 
+#include <http/response_builder.h>
 #include <http/response_parser.h>
+#include <http/standards/rfc2616_response_builder_impl.h>
 #include <http/standards/rfc2616_response_parser_impl.h>
 
 namespace http
 {
 	class rfc2616_response_parser_impl;
+	class rfc2616_response_builder_impl;
 
-	struct rfc2616
+	class rfc2616
 	{
-		using parser_t = rfc2616_response_parser_impl;
+	public:
+		using response_parser_impl_t  = rfc2616_response_parser_impl;
+		using response_builder_impl_t = rfc2616_response_builder_impl;
 	};
 
-	using rfc2616_response_parser = response_parser<rfc2616>;
+	using rfc2616_response_parser  = response_parser<rfc2616>;
+	using rfc2616_response_builder = response_builder<rfc2616>;
 } // namespace http

--- a/include/http/standards/rfc2616_response_builder_impl.h
+++ b/include/http/standards/rfc2616_response_builder_impl.h
@@ -6,41 +6,41 @@
 
 namespace http
 {
-	class server_response_builder
+	class rfc2616_response_builder_impl
 	{
 	public:
+		using string_t		 = std::string;
 		using http_version_t = http_version;
 		using status_code_t	 = status_code;
-		using string_t		 = std::string;
 		using headers_t		 = headers<response_header>;
 		using body_t		 = string_t;
 
 	public:
-		server_response_builder& with_http_version(http_version_t const& v)
+		rfc2616_response_builder_impl& with_http_version(http_version_t const& v)
 		{
 			__http_version = v;
 			return *this;
 		}
 
-		server_response_builder& with_status_code(status_code_t const& sc)
+		rfc2616_response_builder_impl& with_status_code(status_code_t const& sc)
 		{
 			__status_code = sc;
 			return *this;
 		}
 
-		server_response_builder& with_status_message(string_t const& sm)
+		rfc2616_response_builder_impl& with_status_message(string_t const& sm)
 		{
 			__status_message = sm;
 			return *this;
 		}
 
-		server_response_builder& with_header(response_header const& header)
+		rfc2616_response_builder_impl& with_header(response_header const& header)
 		{
 			__headers.add(header);
 			return *this;
 		}
 
-		server_response_builder& with_body(string_t const& body)
+		rfc2616_response_builder_impl& with_body(string_t const& body)
 		{
 			__body = body;
 			return *this;

--- a/include/http/standards/rfc2616_response_parser_impl.h
+++ b/include/http/standards/rfc2616_response_parser_impl.h
@@ -1,7 +1,8 @@
 #pragma once
 
+#include <http/response_builder.h>
 #include <http/response_parser_exception.h>
-#include <http/server_response_builder.h>
+#include <http/standards/rfc2616_response_builder_impl.h>
 #include <iterator>
 
 constexpr auto LINEBREAK_SIZE = 2;
@@ -15,7 +16,7 @@ namespace http
 	class rfc2616_response_parser_impl
 	{
 	public:
-		using builder_t = server_response_builder;
+		using builder_t = rfc2616_response_builder_impl;
 
 	public:
 		rfc2616_response_parser_impl() : __builder {} { }

--- a/include/http/standards/rfc2616_response_parser_impl.h
+++ b/include/http/standards/rfc2616_response_parser_impl.h
@@ -12,13 +12,13 @@ constexpr auto LF			  = '\n';
 
 namespace http
 {
-	class rfc2616_response_parser
+	class rfc2616_response_parser_impl
 	{
 	public:
 		using builder_t = server_response_builder;
 
 	public:
-		rfc2616_response_parser() : __builder {} { }
+		rfc2616_response_parser_impl() : __builder {} { }
 
 		template <typename iterator_t>
 		void parse(iterator_t const& dbegin, iterator_t const& dend)

--- a/testapp/response.cpp
+++ b/testapp/response.cpp
@@ -1,5 +1,5 @@
 #include <http/standards/rfc2616.h>
-#include <http/server_response_builder.h>
+#include <http/response_builder.h>
 #include <http/stdafx.h>
 #include <http/ti_response_parser.h>
 

--- a/testapp/response.cpp
+++ b/testapp/response.cpp
@@ -1,4 +1,4 @@
-#include <http/rfc2616_response_parser.h>
+#include <http/standards/rfc2616.h>
 #include <http/server_response_builder.h>
 #include <http/stdafx.h>
 #include <http/ti_response_parser.h>


### PR DESCRIPTION
Previously, some implementations had the standard injected directly into them. This change extracts the standard implementation into a separate class and makes the base a template in a way, that the user later can implement another standard and use it as an implementation.